### PR TITLE
store app register events from compass

### DIFF
--- a/src/components/editor/editor.jsx
+++ b/src/components/editor/editor.jsx
@@ -25,7 +25,7 @@ class Editor extends PureComponent {
 
   // need to be able to stringify and add spaces to prettify the object
   componentDidMount() {
-    if (this.props.input) {
+    if (this.props.input && this.props.inputQuery !== '') {
       this.editor.setValue(JSON.stringify(JSON.parse(this.props.inputQuery), null, 2));
       this.editor.clearSelection();
     }
@@ -39,7 +39,7 @@ class Editor extends PureComponent {
     }
 
     // set this again in case it's missing
-    if (this.props.input) {
+    if (this.props.input && this.props.inputQuery !== '') {
       this.editor.setValue(JSON.stringify(JSON.parse(this.props.inputQuery), null, 2));
       this.editor.clearSelection();
     }

--- a/src/components/export-modal/export-modal.jsx
+++ b/src/components/export-modal/export-modal.jsx
@@ -13,7 +13,6 @@ class ExportModal extends Component {
 
   static propTypes = {
     exportQuery: PropTypes.object.isRequired,
-    inputQuery: PropTypes.string.isRequired,
     copyQuery: PropTypes.func.isRequired,
     runQuery: PropTypes.func.isRequired
   }
@@ -29,7 +28,7 @@ class ExportModal extends Component {
   // save state, and pass in the currently selected lang
   handleOutputSelect = (outputLang) => {
     this.setState({ outputLang });
-    this.props.runQuery(outputLang.value, this.props.inputQuery);
+    this.props.runQuery(outputLang.value, this.props.exportQuery.inputQuery);
   }
 
   copyHandler = (evt) => {
@@ -95,11 +94,11 @@ class ExportModal extends Component {
             </div>
             <div className={classnames(styles['export-to-lang-form-query'])}>
               <div className={classnames(styles['export-to-lang-form-query-input'])}>
-                <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.state.outputLang.value} inputQuery={this.props.inputQuery} input/>
+                <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.state.outputLang.value} inputQuery={this.props.exportQuery.inputQuery} input/>
                 {errorDiv}
               </div>
               <div className={classnames(styles['export-to-lang-form-query-output'])}>
-                <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.state.outputLang.value} inputQuery={this.props.inputQuery}/>
+                <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.state.outputLang.value} inputQuery={this.props.exportQuery.inputQuery}/>
               </div>
             </div>
           </form>

--- a/src/components/export-to-language/export-to-language.jsx
+++ b/src/components/export-to-language/export-to-language.jsx
@@ -12,11 +12,9 @@ class ExportToLanguage extends Component {
    * @returns {React.Component} The rendered component.
    */
   render() {
-    const inputQuery = '{ "$group" : { "_id": null, "totalPrice": { "$sum": { "$multiply": [ "$price", "$quantity" ]  } } } }';
-
     return (
       <div data-test-id="export-to-language">
-        <ExportModal {...this.props} inputQuery={inputQuery}/>
+        <ExportModal {...this.props} />
       </div>
     );
   }

--- a/src/modules/export-query.js
+++ b/src/modules/export-query.js
@@ -2,15 +2,18 @@ const compiler = require('bson-compilers');
 
 const PREFIX = 'exportQuery';
 
-export const RUN_QUERY = `${PREFIX}/RUN_QUERY`;
+export const ADD_INPUT_QUERY = `${PREFIX}/ADD_INPUT`;
+export const QUERY_ERROR = `${PREFIX}/QUERY_ERROR`;
 export const COPY_QUERY = `${PREFIX}/COPY_QUERY`;
 export const CLEAR_COPY = `${PREFIX}/CLEAR_COPY`;
-export const QUERY_ERROR = `${PREFIX}/QUERY_ERROR`;
+export const RUN_QUERY = `${PREFIX}/RUN_QUERY`;
 
+// TODO: change inputQuery to '' when working with compass
 export const INITIAL_STATE = {
+  queryError: null,
   copySuccess: '',
   returnQuery: '',
-  queryError: null,
+  inputQuery: '',
   copyError: null
 };
 
@@ -55,12 +58,18 @@ export const runQuery = (outputLang, input) => {
 };
 
 export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === ADD_INPUT_QUERY) return { ...state, inputQuery: action.input };
   if (action.type === QUERY_ERROR) return { ...state, queryError: action.error };
   if (action.type === COPY_QUERY) return copyToClipboard(state, action);
   if (action.type === CLEAR_COPY) return getClearCopy(state, action);
 
   return state;
 }
+
+export const addInputQuery = (input) => ({
+  type: ADD_INPUT_QUERY,
+  input: input
+});
 
 export const copyQuery = (input) => ({
   type: COPY_QUERY,

--- a/src/modules/export-query.spec.js
+++ b/src/modules/export-query.spec.js
@@ -1,7 +1,9 @@
 import reducer, {
+  ADD_INPUT_QUERY,
   QUERY_ERROR,
   COPY_QUERY,
   CLEAR_COPY,
+  addInputQuery,
   queryError,
   copyQuery,
   clearCopy,
@@ -36,6 +38,15 @@ describe('export query module', () => {
     });
   });
 
+  describe('#addInputQuery', () => {
+    it('returns a add inputq query input type', () => {
+      expect(addInputQuery('{ "item": "happy socks", "quantity": 2 }')).to.deep.equal({
+        type: ADD_INPUT_QUERY,
+        input: '{ "item": "happy socks", "quantity": 2 }'
+      });
+    });
+  });
+
   describe('#runQuery', () => {
     it('returns state with return query', () => {
       expect(runQuery('csharp', '{x, 1}')).to.be.a('function');
@@ -43,22 +54,36 @@ describe('export query module', () => {
   });
 
   describe('#reducer', () => {
-    context('action type is query error', () => {
+    context('action type is queryError', () => {
       it('query error is has a value in state', () => {
         expect(reducer(undefined, queryError('uh oh'))).to.deep.equal({
           copyError: null,
           copySuccess: '',
+          inputQuery: '',
           queryError: 'uh oh',
           returnQuery: ''
         });
       });
     });
 
-    context('action type is clear copy', () => {
-      it('returns a clear copy state', () => {
+    context('action type is addInputQuery', () => {
+      it('inputQuery has a value in state', () => {
+        expect(reducer(undefined, addInputQuery('{ "beep": "boop" }'))).to.deep.equal({
+          copyError: null,
+          copySuccess: '',
+          inputQuery: '{ "beep": "boop" }',
+          queryError: null,
+          returnQuery: ''
+        });
+      });
+    });
+
+    context('action type is clearCopy', () => {
+      it('returns a clearCopy state', () => {
         expect(reducer(undefined, clearCopy('uh oh'))).to.deep.equal({
           copyError: '',
           copySuccess: '',
+          inputQuery: '',
           queryError: null,
           returnQuery: ''
         });
@@ -70,6 +95,7 @@ describe('export query module', () => {
         expect(reducer(undefined, {})).to.deep.equal({
           copyError: null,
           copySuccess: '',
+          inputQuery: '',
           queryError: null,
           returnQuery: ''
         });

--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -1,54 +1,18 @@
 import { createStore, applyMiddleware } from 'redux';
+import { addInputQuery } from 'modules/export-query';
 import thunk from 'redux-thunk';
 import reducer from 'modules';
 
 const store = createStore(reducer, applyMiddleware(thunk));
 
-// store.onActivated = (appRegistry) => {
-  // Events emitted from the app registry:
-  //
-  // appRegistry.on('application-intialized', (version) => {
-  //   // Version is string in semver format, ex: "1.10.0"
-  // });
-  //
-  // appRegistry.on('data-service-intialized', (dataService) => {
-  //   // dataService is not yet connected. Can subscribe to events.
-  //   // DataService API: https://github.com/mongodb-js/data-service/blob/master/lib/data-service.js
-  // });
-  //
-  // appRegistry.on('data-service-connected', (error, dataService) => {
-  //   // dataService is connected or errored.
-  //   // DataService API: https://github.com/mongodb-js/data-service/blob/master/lib/data-service.js
-  // });
-  //
-  // appRegistry.on('collection-changed', (namespace) => {
-  //   // The collection has changed - provides the current namespace.
-  //   // Namespace format: 'database.collection';
-  //   // Collection selected: 'database.collection';
-  //   // Database selected: 'database';
-  //   // Instance selected: '';
-  // });
-  //
-  // appRegistry.on('database-changed', (namespace) => {
-  //   // The database has changed.
-  //   // Namespace format: 'database.collection';
-  //   // Collection selected: 'database.collection';
-  //   // Database selected: 'database';
-  //   // Instance selected: '';
-  // });
-  //
-  // appRegistry.on('query-applied', (queryState) => {
-  //   // The query has changed and the user has clicked "filter" or "reset".
-  //   // queryState format example:
-  //   //   {
-  //   //     filter: { name: 'testing' },
-  //   //     project: { name: 1 },
-  //   //     sort: { name: -1 },
-  //   //     skip: 0,
-  //   //     limit: 20,
-  //   //     ns: 'database.collection'
-  //   //   }
-  // });
-// };
+store.onActivated = (appRegistry) => {
+  appRegistry.on('open-aggregation-export-to-language', (aggregation) => {
+    store.dispatch(addInputQuery(aggregation));
+  });
+
+  appRegistry.on('open-query-export-to-language', (query) => {
+    store.dispatch(addInputQuery(query));
+  });
+};
 
 export default store;

--- a/src/stores/store.spec.js
+++ b/src/stores/store.spec.js
@@ -4,9 +4,10 @@ describe('ExportToLanguage Store', () => {
   describe('initial store state', () => {
     expect(store.getState()).to.deep.equal({
       exportQuery: {
+        queryError: null,
         copySuccess: '',
         returnQuery: '',
-        queryError: null,
+        inputQuery: '',
         copyError: null
       }
     });


### PR DESCRIPTION
this PR adds two `appRegistry` listeners for `open-aggregation-export-to-language` and `open-query-export-to-language`. Both will dispatch an `addInputQuery` that adds `inputQuery` to the current state. This `inputQuery` is used to populate the left hand-side editor in the modal, as well as used for input to pass in to `bson-compilers`.