### PR TITLE
refactor modal

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -19,7 +19,7 @@ const GLOBALS = {
 
 const config = {
   target: 'electron-renderer',
-  devtool: 'source-map',
+  devtool: false,
   entry: {
     // Export the entry to our plugin. Referenced in package.json main.
     index: path.resolve(project.path.src, 'index.js')

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublish": "npm run compile",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "precommit": [ "check" ]
+    "precommit": [ "npm run check" ]
   },
   "license": "Apache-2.0",
   "peerDependencies": {

--- a/src/components/export-form/export-form.jsx
+++ b/src/components/export-form/export-form.jsx
@@ -1,3 +1,4 @@
+import { TextButton } from 'hadron-react-buttons';
 import SelectLang from 'components/select-lang';
 import React, { Component } from 'react';
 import { Alert } from 'react-bootstrap';
@@ -23,12 +24,11 @@ class ExportForm extends Component {
   }
 
   render() {
-    // const copyButtonStyle = classnames({
-    //   'btn': true,
-    //   'btn-sm': true,
-    //   'btn-default': true,
-    //   [ styles['export-to-lang-query-output-editor-copy'] ]: true
-    // });
+    const copyButtonStyle = classnames({
+      [ styles['export-to-lang-query-output-copy'] ]: true,
+      'btn-default': true,
+      'btn': true
+    });
 
     const errorDiv = this.props.exportQuery.queryError
       ? <Alert bsStyle="danger" className={classnames(styles['export-to-lang-query-input-error'])} children={this.props.exportQuery.queryError}/>
@@ -40,16 +40,33 @@ class ExportForm extends Component {
           <p className={classnames(styles['export-to-lang-headers-input'])}>My Query</p>
           <div className={classnames(styles['export-to-lang-headers-output'])}>
             <p className={classnames(styles['export-to-lang-headers-output-title'])}>Export Query To:</p>
-            <SelectLang inputQuery={this.props.exportQuery.inputQuery} setOutputLang={this.props.setOutputLang} runQuery={this.props.runQuery} outputLang={this.props.exportQuery.outputLang}/>
+            <SelectLang
+              inputQuery={this.props.exportQuery.inputQuery}
+              setOutputLang={this.props.setOutputLang}
+              runQuery={this.props.runQuery}
+              outputLang={this.props.exportQuery.outputLang}/>
           </div>
         </div>
         <div className={classnames(styles['export-to-lang-query'])}>
           <div className={classnames(styles['export-to-lang-query-input'])}>
-            <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.props.exportQuery.outputLang} inputQuery={this.props.exportQuery.inputQuery} input/>
+            <Editor
+              outputQuery={this.props.exportQuery.returnQuery}
+              queryError={this.props.exportQuery.queryError}
+              outputLang={this.props.exportQuery.outputLang}
+              inputQuery={this.props.exportQuery.inputQuery}
+              input/>
             {errorDiv}
           </div>
           <div className={classnames(styles['export-to-lang-query-output'])}>
-            <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.props.exportQuery.outputLang} inputQuery={this.props.exportQuery.inputQuery}/>
+            <Editor
+              outputQuery={this.props.exportQuery.returnQuery}
+              queryError={this.props.exportQuery.queryError}
+              outputLang={this.props.exportQuery.outputLang}
+              inputQuery={this.props.exportQuery.inputQuery}/>
+            <TextButton
+              className={copyButtonStyle}
+              text="Copy"
+              clickHandler={this.copyHandler}/>
           </div>
         </div>
       </form>

--- a/src/components/export-form/export-form.jsx
+++ b/src/components/export-form/export-form.jsx
@@ -1,0 +1,60 @@
+import SelectLang from 'components/select-lang';
+import React, { Component } from 'react';
+import { Alert } from 'react-bootstrap';
+import Editor from 'components/editor';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+import styles from './export-form.less';
+
+class ExportForm extends Component {
+  static displayName = 'ExportFormComponent';
+
+  static propTypes = {
+    exportQuery: PropTypes.object.isRequired,
+    setOutputLang: PropTypes.func.isRequired,
+    copyQuery: PropTypes.func.isRequired,
+    runQuery: PropTypes.func.isRequired
+  }
+
+  copyHandler = (evt) => {
+    evt.preventDefault();
+    this.props.copyQuery(this.props.exportQuery.returnQuery);
+  }
+
+  render() {
+    // const copyButtonStyle = classnames({
+    //   'btn': true,
+    //   'btn-sm': true,
+    //   'btn-default': true,
+    //   [ styles['export-to-lang-query-output-editor-copy'] ]: true
+    // });
+
+    const errorDiv = this.props.exportQuery.queryError
+      ? <Alert bsStyle="danger" className={classnames(styles['export-to-lang-query-input-error'])} children={this.props.exportQuery.queryError}/>
+      : '';
+
+    return (
+      <form name="export-to-lang" data-test-id="export-to-lang" className="export-to-lang">
+        <div className={classnames(styles['export-to-lang-headers'])}>
+          <p className={classnames(styles['export-to-lang-headers-input'])}>My Query</p>
+          <div className={classnames(styles['export-to-lang-headers-output'])}>
+            <p className={classnames(styles['export-to-lang-headers-output-title'])}>Export Query To:</p>
+            <SelectLang inputQuery={this.props.exportQuery.inputQuery} setOutputLang={this.props.setOutputLang} runQuery={this.props.runQuery} outputLang={this.props.exportQuery.outputLang}/>
+          </div>
+        </div>
+        <div className={classnames(styles['export-to-lang-query'])}>
+          <div className={classnames(styles['export-to-lang-query-input'])}>
+            <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.props.exportQuery.outputLang} inputQuery={this.props.exportQuery.inputQuery} input/>
+            {errorDiv}
+          </div>
+          <div className={classnames(styles['export-to-lang-query-output'])}>
+            <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.props.exportQuery.outputLang} inputQuery={this.props.exportQuery.inputQuery}/>
+          </div>
+        </div>
+      </form>
+    );
+  }
+}
+
+export default ExportForm;

--- a/src/components/export-form/export-form.jsx
+++ b/src/components/export-form/export-form.jsx
@@ -15,12 +15,14 @@ class ExportForm extends Component {
     exportQuery: PropTypes.object.isRequired,
     setOutputLang: PropTypes.func.isRequired,
     copyQuery: PropTypes.func.isRequired,
+    clearCopy: PropTypes.func.isRequired,
     runQuery: PropTypes.func.isRequired
   }
 
   copyHandler = (evt) => {
     evt.preventDefault();
     this.props.copyQuery(this.props.exportQuery.returnQuery);
+    setTimeout(() => { this.props.clearCopy(); }, 2500);
   }
 
   render() {
@@ -32,6 +34,10 @@ class ExportForm extends Component {
 
     const errorDiv = this.props.exportQuery.queryError
       ? <Alert bsStyle="danger" className={classnames(styles['export-to-lang-query-input-error'])} children={this.props.exportQuery.queryError}/>
+      : '';
+
+    const bubbleDiv = this.props.exportQuery.copySuccess
+      ? <div className={classnames(styles['export-to-lang-query-output-bubble'])}>Copied!</div>
       : '';
 
     return (
@@ -63,6 +69,7 @@ class ExportForm extends Component {
               queryError={this.props.exportQuery.queryError}
               outputLang={this.props.exportQuery.outputLang}
               inputQuery={this.props.exportQuery.inputQuery}/>
+            {bubbleDiv}
             <TextButton
               className={copyButtonStyle}
               text="Copy"

--- a/src/components/export-form/export-form.less
+++ b/src/components/export-form/export-form.less
@@ -1,0 +1,78 @@
+@import (reference) "~less/compass/_theme.less";
+
+.export-to-lang {
+  &-alert {
+    background-color: #b1e0e6;
+    border-color: #b1e0e6;
+    padding: 10px;
+  }
+
+  &-headers {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+    > * {
+      display: flex;
+      align-items: center;
+      padding-bottom: 10px;
+    }
+
+    &-output {
+      padding-left: 10px;
+      width: 50%;
+      display: flex;
+      > * {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      &-title {
+        padding: 10px 10px 0 0;
+      }
+    }
+    &-input {
+      padding-right: 10px;
+      padding-top: 10px;
+      width: 50%;
+    }
+
+  }
+
+  &-query {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+
+    &-input {
+      flex-basis: 0;
+      flex: 1 1 0;
+      width: 50%;
+      padding-right: 10px;
+
+      &-error {
+        margin-top: 10px;
+        padding: 10px;
+      }
+    }
+
+    &-output {
+      flex-basis: 0;
+      flex: 1 1 0;
+      width: 50%;
+      padding-left: 10px;
+
+      &-editor-wrapper {
+        display: flex;
+
+        &-copy {
+          font-size: 12px;
+          text-transform: capitalize;
+          font-weight: 400;
+          margin-right: 15px;
+        }
+      }
+    }
+  }
+}

--- a/src/components/export-form/export-form.less
+++ b/src/components/export-form/export-form.less
@@ -63,6 +63,20 @@
       width: 50%;
       padding-left: 10px;
 
+      &-bubble {
+        position: absolute;
+        top: 40px;
+        right: 25px;
+        border-radius: 3px;
+        color: #fff;
+        padding: 6px;
+        display: inline-block;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        background-color: @gray2;
+      }
+
       &-copy {
         position: absolute;
         top: 75px;

--- a/src/components/export-form/export-form.less
+++ b/src/components/export-form/export-form.less
@@ -63,15 +63,12 @@
       width: 50%;
       padding-left: 10px;
 
-      &-editor-wrapper {
-        display: flex;
-
-        &-copy {
-          font-size: 12px;
-          text-transform: capitalize;
-          font-weight: 400;
-          margin-right: 15px;
-        }
+      &-copy {
+        position: absolute;
+        top: 75px;
+        right: 25px;
+        padding: 0 10px !important;
+        z-index: 1;
       }
     }
   }

--- a/src/components/export-form/index.js
+++ b/src/components/export-form/index.js
@@ -1,0 +1,2 @@
+import ExportForm from './export-form';
+export default ExportForm;

--- a/src/components/export-modal/export-modal.jsx
+++ b/src/components/export-modal/export-modal.jsx
@@ -1,7 +1,7 @@
 import { TextButton } from 'hadron-react-buttons';
+import SelectLang from 'components/select-lang';
 import { Modal, Alert } from 'react-bootstrap';
 import React, { Component } from 'react';
-import Select from 'react-select-plus';
 import Editor from 'components/editor';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
@@ -13,22 +13,9 @@ class ExportModal extends Component {
 
   static propTypes = {
     exportQuery: PropTypes.object.isRequired,
+    setOutputLang: PropTypes.func.isRequired,
     copyQuery: PropTypes.func.isRequired,
     runQuery: PropTypes.func.isRequired
-  }
-
-  // store the current query in state before we pass it to reducer
-  state = {
-    outputLang: {
-      value: '',
-      label: ''
-    }
-  }
-
-  // save state, and pass in the currently selected lang
-  handleOutputSelect = (outputLang) => {
-    this.setState({ outputLang });
-    this.props.runQuery(outputLang.value, this.props.exportQuery.inputQuery);
   }
 
   copyHandler = (evt) => {
@@ -37,22 +24,12 @@ class ExportModal extends Component {
   }
 
   render() {
-    const langOuputOptions = [
-      { value: 'java', label: 'Java' },
-      { value: 'javascript', label: 'Node' },
-      { value: 'csharp', label: 'C#' },
-      { value: 'python', label: 'Python 3' }
-    ];
-
     // const copyButtonStyle = classnames({
     //   'btn': true,
     //   'btn-sm': true,
     //   'btn-default': true,
     //   [ styles['export-to-lang-form-query-output-editor-copy'] ]: true
     // });
-
-    const outputLang = this.state.outputLang;
-    const selectedOutputValue = outputLang && outputLang.value;
 
     const errorDiv = this.props.exportQuery.queryError
       ? <Alert bsStyle="danger" className={classnames(styles['export-to-lang-form-query-input-error'])} children={this.props.exportQuery.queryError}/>
@@ -72,33 +49,20 @@ class ExportModal extends Component {
 
         <Modal.Body>
           <form name="export-to-lang-form" data-test-id="export-to-lang" className="export-to-lang-form">
-            <div className="form-group">
-              <Alert
-                className={classnames(styles['export-to-lang-form-alert'])}
-                children="PROJECT, SORT, SKIP, LIMIT options are not included as part of the exported query."/>
-            </div>
             <div className={classnames(styles['export-to-lang-form-headers'])}>
-              <p className={classnames(styles['export-tolang-form-headers-input'])}>My Query</p>
+              <p className={classnames(styles['export-to-lang-form-headers-input'])}>My Query</p>
               <div className={classnames(styles['export-to-lang-form-headers-output'])}>
                 <p className={classnames(styles['export-to-lang-form-headers-output-title'])}>Export Query To:</p>
-                <Select
-                  name="export-to-lang-form-query-output-select"
-                  className={classnames(styles['export-to-lang-form-headers-output-select'])}
-                  searchable={false}
-                  clearable={false}
-                  placeholder="Java"
-                  value={selectedOutputValue}
-                  onChange={this.handleOutputSelect}
-                  options={langOuputOptions}/>
+                <SelectLang inputQuery={this.props.exportQuery.inputQuery} setOutputLang={this.props.setOutputLang} runQuery={this.props.runQuery} outputLang={this.props.exportQuery.outputLang}/> 
               </div>
             </div>
             <div className={classnames(styles['export-to-lang-form-query'])}>
               <div className={classnames(styles['export-to-lang-form-query-input'])}>
-                <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.state.outputLang.value} inputQuery={this.props.exportQuery.inputQuery} input/>
+                <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.props.exportQuery.outputLang} inputQuery={this.props.exportQuery.inputQuery} input/>
                 {errorDiv}
               </div>
               <div className={classnames(styles['export-to-lang-form-query-output'])}>
-                <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.state.outputLang.value} inputQuery={this.props.exportQuery.inputQuery}/>
+                <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.props.exportQuery.outputLang} inputQuery={this.props.exportQuery.inputQuery}/>
               </div>
             </div>
           </form>

--- a/src/components/export-modal/export-modal.jsx
+++ b/src/components/export-modal/export-modal.jsx
@@ -1,12 +1,8 @@
 import { TextButton } from 'hadron-react-buttons';
-import SelectLang from 'components/select-lang';
-import { Modal, Alert } from 'react-bootstrap';
+import ExportForm from 'components/export-form';
 import React, { Component } from 'react';
-import Editor from 'components/editor';
-import classnames from 'classnames';
+import { Modal } from 'react-bootstrap';
 import PropTypes from 'prop-types';
-
-import styles from './export-modal.less';
 
 class ExportModal extends Component {
   static displayName = 'ExportModalComponent';
@@ -18,23 +14,7 @@ class ExportModal extends Component {
     runQuery: PropTypes.func.isRequired
   }
 
-  copyHandler = (evt) => {
-    evt.preventDefault();
-    this.props.copyQuery(this.props.exportQuery.returnQuery);
-  }
-
   render() {
-    // const copyButtonStyle = classnames({
-    //   'btn': true,
-    //   'btn-sm': true,
-    //   'btn-default': true,
-    //   [ styles['export-to-lang-form-query-output-editor-copy'] ]: true
-    // });
-
-    const errorDiv = this.props.exportQuery.queryError
-      ? <Alert bsStyle="danger" className={classnames(styles['export-to-lang-form-query-input-error'])} children={this.props.exportQuery.queryError}/>
-      : '';
-
     return (
       <Modal
         show
@@ -48,31 +28,11 @@ class ExportModal extends Component {
         </Modal.Header>
 
         <Modal.Body>
-          <form name="export-to-lang-form" data-test-id="export-to-lang" className="export-to-lang-form">
-            <div className={classnames(styles['export-to-lang-form-headers'])}>
-              <p className={classnames(styles['export-to-lang-form-headers-input'])}>My Query</p>
-              <div className={classnames(styles['export-to-lang-form-headers-output'])}>
-                <p className={classnames(styles['export-to-lang-form-headers-output-title'])}>Export Query To:</p>
-                <SelectLang inputQuery={this.props.exportQuery.inputQuery} setOutputLang={this.props.setOutputLang} runQuery={this.props.runQuery} outputLang={this.props.exportQuery.outputLang}/> 
-              </div>
-            </div>
-            <div className={classnames(styles['export-to-lang-form-query'])}>
-              <div className={classnames(styles['export-to-lang-form-query-input'])}>
-                <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.props.exportQuery.outputLang} inputQuery={this.props.exportQuery.inputQuery} input/>
-                {errorDiv}
-              </div>
-              <div className={classnames(styles['export-to-lang-form-query-output'])}>
-                <Editor outputQuery={this.props.exportQuery.returnQuery} queryError={this.props.exportQuery.queryError} outputLang={this.props.exportQuery.outputLang} inputQuery={this.props.exportQuery.inputQuery}/>
-              </div>
-            </div>
-          </form>
+          <ExportForm {...this.props}/>
         </Modal.Body>
 
         <Modal.Footer>
-          <TextButton
-            className="btn btn-default btn-sm"
-            text="Close"
-            clickHandler={()=>{}} />
+          <TextButton className="btn btn-default btn-sm" text="Close" clickHandler={()=>{}} />
         </Modal.Footer>
       </Modal>
     );

--- a/src/components/export-modal/export-modal.less
+++ b/src/components/export-modal/export-modal.less
@@ -28,19 +28,6 @@
         justify-content: center;
       }
 
-      &-select {
-        display: flex;
-        flex-grow: 0.5;
-        align-items: center;
-        justify-content: center;
-        flex-direction: column;
-        text-transform: uppercase;
-        font-size: 12px;
-        line-height: 18px;
-        font-weight: 600;
-        z-index: 100;
-      }
-
       &-title {
         padding: 10px 10px 0 0;
       }

--- a/src/components/export-to-language/export-to-language.jsx
+++ b/src/components/export-to-language/export-to-language.jsx
@@ -1,4 +1,4 @@
-import { runQuery, copyQuery, clearCopy, queryError } from 'modules/export-query';
+import { runQuery, copyQuery, clearCopy, queryError, setOutputLang} from 'modules/export-query';
 import ExportModal from 'components/export-modal';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -38,6 +38,7 @@ const mapStateToProps = (state) => ({
 const MappedExportToLanguage = connect(
   mapStateToProps,
   {
+    setOutputLang,
     queryError,
     copyQuery,
     clearCopy,

--- a/src/components/select-lang/select-lang.jsx
+++ b/src/components/select-lang/select-lang.jsx
@@ -1,15 +1,46 @@
 import React, { PureComponent } from 'react';
+import Select from 'react-select-plus';
 import classnames from 'classnames';
+import PropTypes from 'prop-types';
 
 import styles from './select-lang.less';
 
 class SelectLang extends PureComponent {
   static displayName = 'SelectLangComponent';
 
+  static propTypes = {
+    setOutputLang: PropTypes.func.isRequired,
+    inputQuery: PropTypes.string.isRequired,
+    outputLang: PropTypes.string.isRequired,
+    runQuery: PropTypes.func.isRequired
+  }
+
+  // save state, and pass in the currently selected lang
+  handleOutputSelect = (outputLang) => {
+    this.props.setOutputLang(outputLang.value);
+    this.props.runQuery(outputLang.value, this.props.inputQuery);
+  }
+
   render() {
+    const selectedOutputValue = this.props.outputLang || '';
+
+    const langOuputOptions = [
+      { value: 'java', label: 'Java' },
+      { value: 'javascript', label: 'Node' },
+      { value: 'csharp', label: 'C#' },
+      { value: 'python', label: 'Python 3' }
+    ];
+
     return (
-      <div className={classnames(styles['input-refresh'])}>
-      </div>
+      <Select
+        name="select-lang"
+        className={classnames(styles['select-lang'])}
+        searchable={false}
+        clearable={false}
+        placeholder="Java"
+        value={selectedOutputValue}
+        onChange={this.handleOutputSelect}
+        options={langOuputOptions}/>
     );
   }
 }

--- a/src/components/select-lang/select-lang.less
+++ b/src/components/select-lang/select-lang.less
@@ -1,0 +1,14 @@
+@import (reference) "~less/compass/_theme.less";
+
+.select-lang {
+  display: flex;
+  flex-grow: 0.5;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  text-transform: uppercase;
+  font-size: 12px;
+  line-height: 18px;
+  font-weight: 600;
+  z-index: 100;
+}

--- a/src/modules/export-query.js
+++ b/src/modules/export-query.js
@@ -1,3 +1,4 @@
+const clipboard = require('electron').clipboard;
 const compiler = require('bson-compilers');
 
 const PREFIX = 'exportQuery';
@@ -15,33 +16,17 @@ export const INITIAL_STATE = {
   copySuccess: '',
   returnQuery: '',
   outputLang: '',
-  inputQuery: '', //{ "item": "happysocks", "quantity": 1, "category": [ "clothing", "socks" ] }',
-  copyError: null
+  inputQuery: ''// { "item": "happysocks", "quantity": 1, "category": [ "clothing", "socks" ] }'
 };
 
 function getClearCopy(state, action) {
-  const newState = action.input === 'success'
-    ? { ...state, copySuccess: '' }
-    : { ...state, copyError: '' };
-
-  return newState;
+  return { ...state, copySuccess: '' };
 }
 
 function copyToClipboard(state, action) {
-  const el = document.createElement('input');
-  el.type = 'text';
-  el.setAttribute('styles', 'display: none;');
-  el.value = action.input;
-  document.body.appendChild(el);
-  el.select();
-  const copy = document.execCommand('copy');
-  document.body.removeChild(el);
+  clipboard.writeText(action.input)
 
-  const newState = copy
-    ? { ...state, copySuccess: true }
-    : { ...state, copyError: true };
-
-  return newState;
+  return { ...state, copySuccess: true };
 }
 
 export const runQuery = (outputLang, input) => {

--- a/src/modules/export-query.js
+++ b/src/modules/export-query.js
@@ -3,6 +3,7 @@ const compiler = require('bson-compilers');
 const PREFIX = 'exportQuery';
 
 export const ADD_INPUT_QUERY = `${PREFIX}/ADD_INPUT`;
+export const OUTPUT_LANG = `${PREFIX}/OUTPUT_LANG`;
 export const QUERY_ERROR = `${PREFIX}/QUERY_ERROR`;
 export const COPY_QUERY = `${PREFIX}/COPY_QUERY`;
 export const CLEAR_COPY = `${PREFIX}/CLEAR_COPY`;
@@ -13,7 +14,8 @@ export const INITIAL_STATE = {
   queryError: null,
   copySuccess: '',
   returnQuery: '',
-  inputQuery: '',
+  outputLang: '',
+  inputQuery: '', // { "item": "happysocks", "quantity": 1, "category": [ "clothing", "socks" ] }',
   copyError: null
 };
 
@@ -59,6 +61,7 @@ export const runQuery = (outputLang, input) => {
 
 export default function reducer(state = INITIAL_STATE, action) {
   if (action.type === ADD_INPUT_QUERY) return { ...state, inputQuery: action.input };
+  if (action.type === OUTPUT_LANG) return { ...state, outputLang: action.lang };
   if (action.type === QUERY_ERROR) return { ...state, queryError: action.error };
   if (action.type === COPY_QUERY) return copyToClipboard(state, action);
   if (action.type === CLEAR_COPY) return getClearCopy(state, action);
@@ -66,14 +69,19 @@ export default function reducer(state = INITIAL_STATE, action) {
   return state;
 }
 
+export const setOutputLang = (lang) => ({
+  type: OUTPUT_LANG,
+  lang: lang
+});
+
 export const addInputQuery = (input) => ({
   type: ADD_INPUT_QUERY,
   input: input
 });
 
-export const copyQuery = (input) => ({
-  type: COPY_QUERY,
-  input: input
+export const clearCopy = (copyType) => ({
+  type: CLEAR_COPY,
+  input: copyType
 });
 
 export const queryError = (error) => ({
@@ -81,7 +89,7 @@ export const queryError = (error) => ({
   error: error
 });
 
-export const clearCopy = (copyType) => ({
-  type: CLEAR_COPY,
-  input: copyType
+export const copyQuery = (input) => ({
+  type: COPY_QUERY,
+  input: input
 });

--- a/src/modules/export-query.js
+++ b/src/modules/export-query.js
@@ -15,7 +15,7 @@ export const INITIAL_STATE = {
   copySuccess: '',
   returnQuery: '',
   outputLang: '',
-  inputQuery: '', // { "item": "happysocks", "quantity": 1, "category": [ "clothing", "socks" ] }',
+  inputQuery: '', //{ "item": "happysocks", "quantity": 1, "category": [ "clothing", "socks" ] }',
   copyError: null
 };
 

--- a/src/modules/export-query.js
+++ b/src/modules/export-query.js
@@ -13,18 +13,14 @@ export const RUN_QUERY = `${PREFIX}/RUN_QUERY`;
 // TODO: change inputQuery to '' when working with compass
 export const INITIAL_STATE = {
   queryError: null,
-  copySuccess: '',
+  copySuccess: false,
   returnQuery: '',
   outputLang: '',
-  inputQuery: ''// { "item": "happysocks", "quantity": 1, "category": [ "clothing", "socks" ] }'
+  inputQuery: '' // { "item": "happysocks", "quantity": 1, "category": [ "clothing", "socks" ] }'
 };
 
-function getClearCopy(state, action) {
-  return { ...state, copySuccess: '' };
-}
-
 function copyToClipboard(state, action) {
-  clipboard.writeText(action.input)
+  clipboard.writeText(action.input);
 
   return { ...state, copySuccess: true };
 }
@@ -49,7 +45,7 @@ export default function reducer(state = INITIAL_STATE, action) {
   if (action.type === OUTPUT_LANG) return { ...state, outputLang: action.lang };
   if (action.type === QUERY_ERROR) return { ...state, queryError: action.error };
   if (action.type === COPY_QUERY) return copyToClipboard(state, action);
-  if (action.type === CLEAR_COPY) return getClearCopy(state, action);
+  if (action.type === CLEAR_COPY) return { ...state, copySuccess: false };
 
   return state;
 }
@@ -64,9 +60,8 @@ export const addInputQuery = (input) => ({
   input: input
 });
 
-export const clearCopy = (copyType) => ({
-  type: CLEAR_COPY,
-  input: copyType
+export const clearCopy = () => ({
+  type: CLEAR_COPY
 });
 
 export const queryError = (error) => ({

--- a/src/modules/export-query.spec.js
+++ b/src/modules/export-query.spec.js
@@ -68,7 +68,6 @@ describe('export query module', () => {
     context('action type is queryError', () => {
       it('query error is has a value in state', () => {
         expect(reducer(undefined, queryError('uh oh'))).to.deep.equal({
-          copyError: null,
           copySuccess: '',
           outputLang: '',
           inputQuery: '',
@@ -81,7 +80,6 @@ describe('export query module', () => {
     context('action type is addInputQuery', () => {
       it('inputQuery has a value in state', () => {
         expect(reducer(undefined, addInputQuery('{ "beep": "boop" }'))).to.deep.equal({
-          copyError: null,
           copySuccess: '',
           outputLang: '',
           inputQuery: '{ "beep": "boop" }',
@@ -94,7 +92,6 @@ describe('export query module', () => {
     context('action type is setOutputLang', () => {
       it('inputQuery has a value in state', () => {
         expect(reducer(undefined, setOutputLang('java'))).to.deep.equal({
-          copyError: null,
           copySuccess: '',
           outputLang: 'java',
           inputQuery: '',
@@ -107,7 +104,6 @@ describe('export query module', () => {
     context('action type is clearCopy', () => {
       it('returns a clearCopy state', () => {
         expect(reducer(undefined, clearCopy('uh oh'))).to.deep.equal({
-          copyError: '',
           copySuccess: '',
           inputQuery: '',
           outputLang: '',
@@ -120,7 +116,6 @@ describe('export query module', () => {
     context('an empty action type returns an intial state', () => {
       it('empty initial state comes back', () => {
         expect(reducer(undefined, {})).to.deep.equal({
-          copyError: null,
           copySuccess: '',
           inputQuery: '',
           outputLang: '',

--- a/src/modules/export-query.spec.js
+++ b/src/modules/export-query.spec.js
@@ -1,8 +1,10 @@
 import reducer, {
   ADD_INPUT_QUERY,
+  OUTPUT_LANG,
   QUERY_ERROR,
   COPY_QUERY,
   CLEAR_COPY,
+  setOutputLang,
   addInputQuery,
   queryError,
   copyQuery,
@@ -53,12 +55,22 @@ describe('export query module', () => {
     });
   });
 
+  describe('#setOutputLang', () => {
+    it('returns an outputLang action type', () => {
+      expect(setOutputLang('csharp')).to.deep.equal({
+        type: OUTPUT_LANG,
+        lang: 'csharp'
+      });
+    });
+  });
+
   describe('#reducer', () => {
     context('action type is queryError', () => {
       it('query error is has a value in state', () => {
         expect(reducer(undefined, queryError('uh oh'))).to.deep.equal({
           copyError: null,
           copySuccess: '',
+          outputLang: '',
           inputQuery: '',
           queryError: 'uh oh',
           returnQuery: ''
@@ -71,7 +83,21 @@ describe('export query module', () => {
         expect(reducer(undefined, addInputQuery('{ "beep": "boop" }'))).to.deep.equal({
           copyError: null,
           copySuccess: '',
+          outputLang: '',
           inputQuery: '{ "beep": "boop" }',
+          queryError: null,
+          returnQuery: ''
+        });
+      });
+    });
+
+    context('action type is setOutputLang', () => {
+      it('inputQuery has a value in state', () => {
+        expect(reducer(undefined, setOutputLang('java'))).to.deep.equal({
+          copyError: null,
+          copySuccess: '',
+          outputLang: 'java',
+          inputQuery: '',
           queryError: null,
           returnQuery: ''
         });
@@ -84,6 +110,7 @@ describe('export query module', () => {
           copyError: '',
           copySuccess: '',
           inputQuery: '',
+          outputLang: '',
           queryError: null,
           returnQuery: ''
         });
@@ -96,6 +123,7 @@ describe('export query module', () => {
           copyError: null,
           copySuccess: '',
           inputQuery: '',
+          outputLang: '',
           queryError: null,
           returnQuery: ''
         });

--- a/src/modules/export-query.spec.js
+++ b/src/modules/export-query.spec.js
@@ -33,9 +33,8 @@ describe('export query module', () => {
 
   describe('#clearCopy', () => {
     it('returns a clear copy action type', () => {
-      expect(clearCopy('type')).to.deep.equal({
-        type: CLEAR_COPY,
-        input: 'type'
+      expect(clearCopy()).to.deep.equal({
+        type: CLEAR_COPY
       });
     });
   });
@@ -68,11 +67,11 @@ describe('export query module', () => {
     context('action type is queryError', () => {
       it('query error is has a value in state', () => {
         expect(reducer(undefined, queryError('uh oh'))).to.deep.equal({
-          copySuccess: '',
-          outputLang: '',
-          inputQuery: '',
+          copySuccess: false,
           queryError: 'uh oh',
-          returnQuery: ''
+          returnQuery: '',
+          outputLang: '',
+          inputQuery: ''
         });
       });
     });
@@ -80,11 +79,11 @@ describe('export query module', () => {
     context('action type is addInputQuery', () => {
       it('inputQuery has a value in state', () => {
         expect(reducer(undefined, addInputQuery('{ "beep": "boop" }'))).to.deep.equal({
-          copySuccess: '',
-          outputLang: '',
           inputQuery: '{ "beep": "boop" }',
+          copySuccess: false,
           queryError: null,
-          returnQuery: ''
+          returnQuery: '',
+          outputLang: ''
         });
       });
     });
@@ -92,23 +91,23 @@ describe('export query module', () => {
     context('action type is setOutputLang', () => {
       it('inputQuery has a value in state', () => {
         expect(reducer(undefined, setOutputLang('java'))).to.deep.equal({
-          copySuccess: '',
+          copySuccess: false,
           outputLang: 'java',
-          inputQuery: '',
           queryError: null,
-          returnQuery: ''
+          returnQuery: '',
+          inputQuery: ''
         });
       });
     });
 
     context('action type is clearCopy', () => {
       it('returns a clearCopy state', () => {
-        expect(reducer(undefined, clearCopy('uh oh'))).to.deep.equal({
-          copySuccess: '',
-          inputQuery: '',
-          outputLang: '',
+        expect(reducer(undefined, clearCopy())).to.deep.equal({
+          copySuccess: false,
           queryError: null,
-          returnQuery: ''
+          returnQuery: '',
+          inputQuery: '',
+          outputLang: ''
         });
       });
     });
@@ -116,11 +115,11 @@ describe('export query module', () => {
     context('an empty action type returns an intial state', () => {
       it('empty initial state comes back', () => {
         expect(reducer(undefined, {})).to.deep.equal({
-          copySuccess: '',
-          inputQuery: '',
-          outputLang: '',
+          copySuccess: false,
           queryError: null,
-          returnQuery: ''
+          returnQuery: '',
+          inputQuery: '',
+          outputLang: ''
         });
       });
     });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,6 +1,6 @@
+import ExportToLanguage from 'components/export-to-language';
 import React, { Component } from 'react';
 import { Provider } from 'react-redux';
-import ExportToLanguage from 'components/export-to-language';
 import store from 'stores';
 
 class Plugin extends Component {

--- a/src/stores/store.spec.js
+++ b/src/stores/store.spec.js
@@ -7,6 +7,7 @@ describe('ExportToLanguage Store', () => {
         queryError: null,
         copySuccess: '',
         returnQuery: '',
+        outputLang: '',
         inputQuery: '',
         copyError: null
       }

--- a/src/stores/store.spec.js
+++ b/src/stores/store.spec.js
@@ -8,8 +8,7 @@ describe('ExportToLanguage Store', () => {
         copySuccess: '',
         returnQuery: '',
         outputLang: '',
-        inputQuery: '',
-        copyError: null
+        inputQuery: ''
       }
     });
   });

--- a/src/stores/store.spec.js
+++ b/src/stores/store.spec.js
@@ -4,8 +4,8 @@ describe('ExportToLanguage Store', () => {
   describe('initial store state', () => {
     expect(store.getState()).to.deep.equal({
       exportQuery: {
+        copySuccess: false,
         queryError: null,
-        copySuccess: '',
         returnQuery: '',
         outputLang: '',
         inputQuery: ''


### PR DESCRIPTION
fixes a few things:

- [x] selectbox is now its own component
- [x] form is now its own component
- [x] copy to clipboard now happens in electron's clipboard context (wayyy easier than `document.execCommand`)
- [x] there is a lil bubble that comes up and goes away when you copy a thing
- [x] `outputLang` is set on the module's state to be used in internal components easier