### PR TITLE
make copy button green! :seedling:

### DIFF
--- a/src/components/export-form/export-form.jsx
+++ b/src/components/export-form/export-form.jsx
@@ -1,4 +1,4 @@
-import { TextButton } from 'hadron-react-buttons';
+import { IconTextButton } from 'hadron-react-buttons';
 import SelectLang from 'components/select-lang';
 import React, { Component } from 'react';
 import { Alert } from 'react-bootstrap';
@@ -28,7 +28,8 @@ class ExportForm extends Component {
   render() {
     const copyButtonStyle = classnames({
       [ styles['export-to-lang-query-output-copy'] ]: true,
-      'btn-default': true,
+      'btn-sm': true,
+      'btn-info': true,
       'btn': true
     });
 
@@ -70,8 +71,9 @@ class ExportForm extends Component {
               outputLang={this.props.exportQuery.outputLang}
               inputQuery={this.props.exportQuery.inputQuery}/>
             {bubbleDiv}
-            <TextButton
+            <IconTextButton
               className={copyButtonStyle}
+              iconClassName="fa fa-paste"
               text="Copy"
               clickHandler={this.copyHandler}/>
           </div>

--- a/src/components/export-form/export-form.less
+++ b/src/components/export-form/export-form.less
@@ -81,8 +81,10 @@
         position: absolute;
         top: 75px;
         right: 25px;
-        padding: 0 10px !important;
         z-index: 1;
+        > * {
+          padding-right: 5px;
+        }
       }
     }
   }

--- a/src/components/export-modal/export-modal.jsx
+++ b/src/components/export-modal/export-modal.jsx
@@ -20,7 +20,6 @@ class ExportModal extends Component {
         show
         backdrop="static"
         bsSize="large"
-        onHide={this.onExportModalToggle}
         dialogClassName="export-to-lang-modal">
 
         <Modal.Header>


### PR DESCRIPTION
uses `btn-small` and `btn-info` classes to make the button green; also adds a little clipboard sign to distinguish it's a copy button.

![screen shot 2018-06-07 at 11 06 15 am](https://user-images.githubusercontent.com/8107784/41089763-e80d6464-6a42-11e8-901f-9e0482145676.png)
