### PR TITLE
CLOUDP-39636: Small Typo Fix

### DIFF
--- a/src/modules/copy-to-clipboard.js
+++ b/src/modules/copy-to-clipboard.js
@@ -25,7 +25,7 @@ export const INITIAL_STATE = (action) => {
  */
 export default function reducer(state = INITIAL_STATE, action) {
   if (action.type === COPY_TO_CLIPBOARD_FN_CHANGED) {
-    return action.copyToClipboardFnChanged;
+    return action.copyToClipboard;
   }
 
   return state;


### PR DESCRIPTION
CLOUDP-39636: Small typo fix to allow providing a different copy to clipboard function


## Description
This is a small fix for a typo that I think creeped in by accident. The action contains the new clipboard function on `action.copyToClipboard` but we're trying to read it off of `action.copyToClipboardFnChanged`. I've renamed it here

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Dependents
Can we get one more version bump once this is merged? Our incorporation of the latest export to language features is dependent on this.

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
